### PR TITLE
use `zombienet` to create chain-spec and remove extra steps

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,13 +1,6 @@
 set dotenv-load
 
-default: chainspec spawn
-
-chainspec:
-  $RUNTIMES/target/release/chain-spec-generator polkadot-local > relaychain-spec.json
-  python3 patch-chainspec.py relaychain-spec.json $RUNTIMES/target/release/wbuild/polkadot-runtime/polkadot_runtime.compact.compressed.wasm
-
-  $RUNTIMES/target/release/chain-spec-generator asset-hub-polkadot-local > assethub-spec.json
-  python3 patch-chainspec.py assethub-spec.json $RUNTIMES/target/release/wbuild/asset-hub-polkadot-runtime/asset_hub_polkadot_runtime.compact.compressed.wasm
+default: spawn
 
 spawn:
   PATH="$PATH:$POLKADOT:$POLKADOT_PARACHAIN" zombienet spawn simple.toml --provider native

--- a/simple.toml
+++ b/simple.toml
@@ -1,7 +1,8 @@
 [relaychain]
 default_command = "../polkadot-sdk/target/release/polkadot"
 default_args = [ "-lparachain=debug" ]
-chain_spec_path = "relaychain-spec.json"
+chain = "polkadot-local"
+chain_spec_command = "{{RUNTIMES}}/target/release/chain-spec-generator {% raw %} {{chainName}} {% endraw %}"
 
   [[relaychain.nodes]]
   name = "Relay1"
@@ -13,9 +14,10 @@ chain_spec_path = "relaychain-spec.json"
 
 [[parachains]]
 id = 1000
-chain_spec_path = "assethub-spec.json"
 add_to_genesis = true
 cumulus_based = true
+chain = "asset-hub-polkadot-local"
+chain_spec_command = "{{RUNTIMES}}/target/release/chain-spec-generator {% raw %} {{chainName}} {% endraw %}"
 
   [[parachains.collators]]
   name = "AssetHub"


### PR DESCRIPTION
Hi @ggwpez, I changed the config to allow zombienet to create the chain-spec directly. And also fixed the block production for asset-hub, since we use some matching on the chain name to inject the appropriated keys in the spec.

Thanks!! 